### PR TITLE
Security: Unsafe use of eval() for code execution

### DIFF
--- a/js/海洋听书.js
+++ b/js/海洋听书.js
@@ -33,7 +33,7 @@ var rule = {
             let v = pd(html, ".booksite&&script&&Html");
             var document = {};
             var VideoListJson;
-            VideoListJson = eval(v.split("VideoListJson=")[1].split(",urlinfo")[0]);
+            VideoListJson = JSON.parse(v.split("VideoListJson=")[1].split(",urlinfo")[0]);
             // log(typeof VideoListJson);
             let list1 = VideoListJson[0][1];
             LISTS = [list1];


### PR DESCRIPTION
## Problem

Multiple JavaScript rule files use eval() to parse dynamic content, allowing arbitrary code execution if the server returns malicious data. Found in js/海洋听书.js, js/有声小说吧.js and others.

**Severity**: `critical`
**File**: `js/海洋听书.js`

## Solution

Replace eval() with JSON.parse() or implement safe parsing. Example: Use JSON.parse() instead of eval() for parsing VideoListJson.

## Changes

- `js/海洋听书.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
